### PR TITLE
Build for 2GB boards as well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ sdcard: uefi_release
 	parted -s sdcard.img unit s mkpart uboot 8MiB 16MiB
 	parted -s sdcard.img unit s mkpart env 16MiB 32MiB
 
-	for size in 4GB 8GB; do						\
+	for size in 2GB 4GB 8GB; do					\
 		cp sdcard.img sdcard_$${size}.img;			\
 		dd if=idblock.bin of=sdcard_$${size}.img 		\
 		    seek=64 conv=notrunc;				\
@@ -29,6 +29,7 @@ sdcard: uefi_release
 
 .PHONY: release
 release: sdcard
+	gzip sdcard_2GB.img
 	gzip sdcard_4GB.img
 	gzip sdcard_8GB.img
 

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,8 @@ test -r rkbin/${BL31} || (echo "rkbin/${BL31} not found"; false)
 . edk2/edksetup.sh
 
 build_uefitools
+build_uefi 0x80000000
+build_fit 2GB
 build_uefi 0xF0000000
 build_fit 4GB
 build_uefi 0x200000000


### PR DESCRIPTION
The SOQuartz in particular comes in 2GB as well as the RADXA ROCK3 Model A mentioned in one of the issues.  SOQuartz 2GB can load UEFI/grub/Linux kernel but does not find devices yet.