### PR TITLE
Rk356x: make SDMMC0_PWREN optional

### DIFF
--- a/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
+++ b/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
@@ -451,6 +451,7 @@
   #
   # The Quartz64 board has inverted polarity for the PWREN pin on the SD card slot
   #
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|TRUE
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|TRUE
 
 [PcdsDynamicHii.common.DEFAULT]

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/MshcDxe/MshcDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/MshcDxe/MshcDxe.c
@@ -756,18 +756,20 @@ MshcDxeInitialize (
 
   /* Configure pins */
   GpioSetIomuxConfig (mSdmmc0IomuxConfig, ARRAY_SIZE (mSdmmc0IomuxConfig));
-  if (!PcdGetBool (PcdMshcDxePwrEnInverted)) {
-    GpioSetIomuxConfig (mSdmmc0IomuxPwrEnDefaultConfig, ARRAY_SIZE (mSdmmc0IomuxPwrEnDefaultConfig));
-  } else {
-    /*
-    * This board has the PWREN signal from SDMMC0 inverted. Configure the
-    * pin as GPIO and drive it low since there is no way with the device tree
-    * bindings to tell the driver about this quirk.
-    */
-    DEBUG ((DEBUG_INFO, "MshcDxeInitialize(): Applying PWREN inverted workaround\n"));
-    GpioSetIomuxConfig (mSdmmc0IomuxPwrEnInvertedConfig, ARRAY_SIZE (mSdmmc0IomuxPwrEnInvertedConfig));
-    GpioPinSetDirection (0, GPIO_PIN_PA5, GPIO_PIN_OUTPUT);
-    GpioPinWrite (0, GPIO_PIN_PA5, FALSE);
+  if (PcdGetBool (PcdMshcDxePwrEnUsed)) {
+    if (!PcdGetBool (PcdMshcDxePwrEnInverted)) {
+      GpioSetIomuxConfig (mSdmmc0IomuxPwrEnDefaultConfig, ARRAY_SIZE (mSdmmc0IomuxPwrEnDefaultConfig));
+    } else {
+      /*
+      * This board has the PWREN signal from SDMMC0 inverted. Configure the
+      * pin as GPIO and drive it low since there is no way with the device tree
+      * bindings to tell the driver about this quirk.
+      */
+      DEBUG ((DEBUG_INFO, "MshcDxeInitialize(): Applying PWREN inverted workaround\n"));
+      GpioSetIomuxConfig (mSdmmc0IomuxPwrEnInvertedConfig, ARRAY_SIZE (mSdmmc0IomuxPwrEnInvertedConfig));
+      GpioPinSetDirection (0, GPIO_PIN_PA5, GPIO_PIN_OUTPUT);
+      GpioPinWrite (0, GPIO_PIN_PA5, FALSE);
+    }
   }
 
   MshcAdjustFifoThreshold ();

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/MshcDxe/MshcDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/MshcDxe/MshcDxe.inf
@@ -46,6 +46,7 @@
   gRk356xTokenSpaceGuid.PcdMshcDxeBaseAddress
   gRk356xTokenSpaceGuid.PcdMshcDxeMaxClockFreqInHz
   gRk356xTokenSpaceGuid.PcdMshcDxeFifoDepth
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted
 
 [Depex]

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
@@ -31,7 +31,8 @@
   gRk356xTokenSpaceGuid.PcdMshcDxeBaseAddress|0xFE2B0000|UINT32|0x00000007
   gRk356xTokenSpaceGuid.PcdMshcDxeMaxClockFreqInHz|50000000|UINT32|0x00000008
   gRk356xTokenSpaceGuid.PcdMshcDxeFifoDepth|0x100|UINT32|0x00000009
-  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|FALSE|BOOLEAN|0x0000000A
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|FALSE|BOOLEAN|0x0000000A
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|FALSE|BOOLEAN|0x0000000B
   # Pcds for PCIe
   gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|0xFFFFFFFF|UINT32|0x00000010
   gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|0xFFFFFFFF|UINT32|0x00000011


### PR DESCRIPTION
SOQuartz and ROC-RK3566-PC both don't use SDMMC0_PWREN at all for SDMMC
purposes.  Instead on one board it's used as interrupt pin for the touch
panel.  Hence only configure the pin if necessary.