### PR TITLE
ROC-RK3566-PC: add support for WiFi chips on second SD controller

### DIFF
--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -100,6 +100,17 @@ STATIC CONST GPIO_IOMUX_CONFIG mGmac1IomuxConfig[] = {
   { "gmac1_txd3m0",       3, GPIO_PIN_PA3, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
 };
 
+STATIC CONST GPIO_IOMUX_CONFIG mSdmmc1IomuxConfig[] = {
+  { "sdmmc1_d0",          2, GPIO_PIN_PA3, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d1",          2, GPIO_PIN_PA4, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d2",          2, GPIO_PIN_PA5, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d3",          2, GPIO_PIN_PA6, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_cmd",         2, GPIO_PIN_PA7, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_clk",         2, GPIO_PIN_PB0, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_pwren",       2, GPIO_PIN_PB1, 0, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "sdmmc1_det",         2, GPIO_PIN_PB2, 0, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+};
+
 STATIC
 EFI_STATUS
 BoardInitSetCpuSpeed (
@@ -357,6 +368,28 @@ BoardInitPmic (
   PmicWrite (PMIC_POWER_EN3, 0x11);
 }
 
+STATIC
+VOID
+BoardInitWiFi (
+  VOID
+  )
+{
+  DEBUG ((DEBUG_INFO, "BOARD: WiFi init\n"));
+
+  CruSetSdmmcClockRate (1, 100000000UL);
+
+  /* Configure pins */
+  GpioSetIomuxConfig (mSdmmc1IomuxConfig, ARRAY_SIZE (mSdmmc1IomuxConfig));
+
+  /* Set GPIO2 PB1 (WIFI_REG_ON) output high to enable WiFi */
+  GpioPinSetDirection (2, GPIO_PIN_PB1, GPIO_PIN_OUTPUT);
+  MicroSecondDelay (1000);
+  GpioPinWrite (2, GPIO_PIN_PB1, FALSE);
+  MicroSecondDelay (500000);
+  GpioPinWrite (2, GPIO_PIN_PB1, TRUE);
+  MicroSecondDelay (100000);
+}
+
 EFI_STATUS
 EFIAPI
 BoardInitDriverEntryPoint (
@@ -394,6 +427,9 @@ BoardInitDriverEntryPoint (
 
   /* GMAC setup */
   BoardInitGmac ();
+
+  /* WiFi setup */
+  BoardInitWiFi ();
 
   return EFI_SUCCESS;
 }

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
@@ -448,6 +448,13 @@
   gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0
   gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|20
 
+  #
+  # The ROC-RK3566-PC has a WiFi card on the second MSHC
+  #
+  gRk356xTokenSpaceGuid.PcdMshc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq|TRUE
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable|TRUE
+
 [PcdsDynamicHii.common.DEFAULT]
 
   #

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Mshc.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Mshc.asl
@@ -34,3 +34,49 @@ Device (MSH0) {
         Return (RBUF)
     }
 }
+
+// Mobile Storage Host Controller
+Device (MSH1) {
+    Name (_HID, "PRP0001")
+    Name (_UID, 4)
+    Name (_CCA, Zero)
+
+    Name (_DSD, Package () {
+        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+        Package () {
+            Package () { "compatible", Package () { "rockchip,rk3568-dw-mshc", "rockchip,rk3288-dw-mshc" } },
+            Package () { "fifo-depth", 0x100 },
+            Package () { "max-frequency", 50000000 },
+            Package () { "bus-width", 4 },
+            Package () { "cap-sd-highspeed", 1 },
+#if FixedPcdGetBool(PcdMshc1SdioIrq) == 1
+            Package () { "cap-sdio-irq", 1 },
+#endif
+            Package () { "disable-wp", 1 },
+#if FixedPcdGetBool(PcdMshc1NonRemovable) == 1
+            Package () { "non-removable", 1 }
+#endif
+        }
+    })
+
+    Method (_CRS, 0x0, Serialized) {
+        Name (RBUF, ResourceTemplate() {
+            Memory32Fixed (ReadWrite, 0xFE2C0000, 0x4000)
+            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 131 }
+        })
+        Return (RBUF)
+    }
+
+    Name (_STA, FixedPcdGet8(PcdMshc1Status))
+
+#if FixedPcdGetBool(PcdMshc1NonRemovable) == 1
+    Device (SDMM) {
+        Method (_ADR) {
+            Return (0)
+        }
+        Method (_RMV) {
+            Return (0) // non-removable
+        }
+    }
+#endif
+}

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Quartz64.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Quartz64.inf
@@ -56,5 +56,9 @@
   gRk356xTokenSpaceGuid.PcdUsb2Size
   gRk356xTokenSpaceGuid.PcdNumUsb2Controller
 
+  gRk356xTokenSpaceGuid.PcdMshc1Status
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable
+
 [BuildOptions]
   GCC:*_*_*_ASL_FLAGS       = -vw3133 -vw3150

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC.inf
@@ -56,5 +56,9 @@
   gRk356xTokenSpaceGuid.PcdUsb2Size
   gRk356xTokenSpaceGuid.PcdNumUsb2Controller
 
+  gRk356xTokenSpaceGuid.PcdMshc1Status
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable
+
 [BuildOptions]
   GCC:*_*_*_ASL_FLAGS       = -vw3133 -vw3150

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3568-PC.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3568-PC.inf
@@ -56,5 +56,9 @@
   gRk356xTokenSpaceGuid.PcdUsb2Size
   gRk356xTokenSpaceGuid.PcdNumUsb2Controller
 
+  gRk356xTokenSpaceGuid.PcdMshc1Status
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable
+
 [BuildOptions]
   GCC:*_*_*_ASL_FLAGS       = -vw3133 -vw3150

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/SOQuartz.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/SOQuartz.inf
@@ -56,5 +56,9 @@
   gRk356xTokenSpaceGuid.PcdUsb2Size
   gRk356xTokenSpaceGuid.PcdNumUsb2Controller
 
+  gRk356xTokenSpaceGuid.PcdMshc1Status
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable
+
 [BuildOptions]
   GCC:*_*_*_ASL_FLAGS       = -vw3133 -vw3150

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
@@ -28,15 +28,18 @@
   gRk356xTokenSpaceGuid.PcdNumUsb3Controller|2|UINT32|0x00000005
   gRk356xTokenSpaceGuid.PcdUsbPhyGrfBaseAddr|0xFDCA0000|UINT64|0x00000006
   # Pcds for MSHC
-  gRk356xTokenSpaceGuid.PcdMshcDxeBaseAddress|0xFE2B0000|UINT32|0x00000007
-  gRk356xTokenSpaceGuid.PcdMshcDxeMaxClockFreqInHz|50000000|UINT32|0x00000008
-  gRk356xTokenSpaceGuid.PcdMshcDxeFifoDepth|0x100|UINT32|0x00000009
-  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|FALSE|BOOLEAN|0x0000000A
-  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|FALSE|BOOLEAN|0x0000000B
+  gRk356xTokenSpaceGuid.PcdMshcDxeBaseAddress|0xFE2B0000|UINT32|0x00000010
+  gRk356xTokenSpaceGuid.PcdMshcDxeMaxClockFreqInHz|50000000|UINT32|0x00000011
+  gRk356xTokenSpaceGuid.PcdMshcDxeFifoDepth|0x100|UINT32|0x00000012
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|FALSE|BOOLEAN|0x00000013
+  gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|FALSE|BOOLEAN|0x00000014
+  gRk356xTokenSpaceGuid.PcdMshc1Status|0x0|UINT8|0x00000015
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq|FALSE|BOOLEAN|0x00000016
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable|FALSE|BOOLEAN|0x00000017
   # Pcds for PCIe
-  gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|0xFFFFFFFF|UINT32|0x00000010
-  gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|0xFFFFFFFF|UINT32|0x00000011
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0xFFFFFFFF|UINT32|0x00000012
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|0xFFFFFFFF|UINT32|0x00000013
-  gRk356xTokenSpaceGuid.PcdPcieLinkSpeed|0x2|UINT32|0x00000014
-  gRk356xTokenSpaceGuid.PcdPcieNumLanes|0x1|UINT32|0x00000015
+  gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|0xFFFFFFFF|UINT32|0x00000020
+  gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|0xFFFFFFFF|UINT32|0x00000021
+  gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0xFFFFFFFF|UINT32|0x00000022
+  gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|0xFFFFFFFF|UINT32|0x00000023
+  gRk356xTokenSpaceGuid.PcdPcieLinkSpeed|0x2|UINT32|0x00000024
+  gRk356xTokenSpaceGuid.PcdPcieNumLanes|0x1|UINT32|0x00000025


### PR DESCRIPTION
This provides the ACPI table information for the second MSHC on the
RK3566.  This one is commonly used to connect WiFi SDIO cards.  Since
not all boards have it routed, make the controller optional and only
enable it on the ROK-RK3566-PC.

Initialize the WiFi and MSHC controller by configuring the IOMUX, the
SDMMC1 clock and power cycling the WiFi card.

Reorder the PCD identifier to leave some gap between the components.