### PR TITLE
SOQuartz: update GPIO pins

### DIFF
--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -164,9 +164,9 @@ BoardInitDriverEntryPoint (
 
   DEBUG ((DEBUG_INFO, "BoardInitDriverEntryPoint() called\n"));
 
-  /* Set GPIO0 PD3 (WORK_LED) output high to enable LED */
-  GpioPinSetDirection (0, GPIO_PIN_PD3, GPIO_PIN_OUTPUT);
-  GpioPinWrite (0, GPIO_PIN_PD3, TRUE);
+  /* Set GPIO0 PC0 (WORK_LED) output low to enable LED */
+  GpioPinSetDirection (0, GPIO_PIN_PC0, GPIO_PIN_OUTPUT);
+  GpioPinWrite (0, GPIO_PIN_PC0, FALSE);
 
   /* Update CPU speed */
   BoardInitSetCpuSpeed ();
@@ -177,10 +177,6 @@ BoardInitDriverEntryPoint (
   /* Configure MULTI-PHY 0 and 1 for USB3 mode */
   MultiPhySetMode (0, MULTIPHY_MODE_USB3);
   MultiPhySetMode (1, MULTIPHY_MODE_USB3);
-
-  /* Set GPIO4 PB5 (USB_HOST_PWREN) output high to power USB ports */
-  GpioPinSetDirection (4, GPIO_PIN_PB5, GPIO_PIN_OUTPUT);
-  GpioPinWrite (4, GPIO_PIN_PB5, TRUE);
 
   return EFI_SUCCESS;
 }

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -444,8 +444,6 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciIoTranslation|0x000000033FFF0000
   gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|1
   gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|10
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|22
 
 [PcdsDynamicHii.common.DEFAULT]
 

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
@@ -76,10 +76,10 @@
 #define IATU_LWR_TARGET_ADDR_OFF        0x014
 #define IATU_UPPER_TARGET_ADDR_OFF      0x018
 
-#define PCIE_POWER_GPIO_BANK            FixedPcdGet32 (PcdPciePowerGpioBank)
-#define PCIE_POWER_GPIO_PIN             FixedPcdGet32 (PcdPciePowerGpioPin)
-#define PCIE_RESET_GPIO_BANK            FixedPcdGet32 (PcdPcieResetGpioBank)
-#define PCIE_RESET_GPIO_PIN             FixedPcdGet32 (PcdPcieResetGpioPin)
+#define PCIE_POWER_GPIO_BANK            FixedPcdGet8  (PcdPciePowerGpioBank)
+#define PCIE_POWER_GPIO_PIN             FixedPcdGet8  (PcdPciePowerGpioPin)
+#define PCIE_RESET_GPIO_BANK            FixedPcdGet8  (PcdPcieResetGpioBank)
+#define PCIE_RESET_GPIO_PIN             FixedPcdGet8  (PcdPcieResetGpioPin)
 #define PCIE_LINK_SPEED                 FixedPcdGet32 (PcdPcieLinkSpeed)
 #define PCIE_NUM_LANES                  FixedPcdGet32 (PcdPcieNumLanes)
 
@@ -296,11 +296,11 @@ InitializePciHost (
   UINT64                   PciIoBase;
   UINT64                   PciIoSize;
 
-  ASSERT (PCIE_RESET_GPIO_BANK != 0xFFFFFFFFU);
-  ASSERT (PCIE_RESET_GPIO_PIN != 0xFFFFFFFFU);
+  ASSERT (PCIE_RESET_GPIO_BANK != 0xFFU);
+  ASSERT (PCIE_RESET_GPIO_PIN != 0xFFU);
 
   /* Power PCIe */
-  if (PCIE_POWER_GPIO_BANK != 0xFFFFFFFFU) {
+  if (PCIE_POWER_GPIO_BANK != 0xFFU) {
     GpioPinSetPull (PCIE_POWER_GPIO_BANK, PCIE_POWER_GPIO_PIN, GPIO_PIN_PULL_NONE);
     GpioPinSetDirection (PCIE_POWER_GPIO_BANK, PCIE_POWER_GPIO_PIN, GPIO_PIN_OUTPUT);
     GpioPinWrite (PCIE_POWER_GPIO_BANK, PCIE_POWER_GPIO_PIN, TRUE);

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
@@ -39,9 +39,9 @@
   # Pcds for eMMC
   gRk356xTokenSpaceGuid.PcdEmmcDxeBaseAddress|0xFE310000|UINT32|0x00000020
   # Pcds for PCIe
-  gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|0xFFFFFFFF|UINT32|0x00000030
-  gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|0xFFFFFFFF|UINT32|0x00000031
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0xFFFFFFFF|UINT32|0x00000032
-  gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|0xFFFFFFFF|UINT32|0x00000033
+  gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|0xFF|UINT8|0x00000030
+  gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|0xFF|UINT8|0x00000031
+  gRk356xTokenSpaceGuid.PcdPciePowerGpioBank|0xFF|UINT8|0x00000032
+  gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|0xFF|UINT8|0x00000033
   gRk356xTokenSpaceGuid.PcdPcieLinkSpeed|0x2|UINT32|0x00000034
   gRk356xTokenSpaceGuid.PcdPcieNumLanes|0x1|UINT32|0x00000035


### PR DESCRIPTION
The GPIO pins copied from Quartz64 are not correct.  The WORK_LED is on
a different pin, and it needs to be driven low.  There is no GPIO pin to
enable USB host power, only the USB data pins are routed to the carrier.
There is no PCIe power pin, so remove those settings.  Unfortunately we
also have to change the PCIe host code, as passing the define being set
to 0xffffffff to a function that only takes UINT8 makes the compiler
error out.