### PR TITLE
SOQuartz: sync with Quartz64 & ROC-RK3566-PC

### DIFF
--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -17,14 +17,90 @@
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
 #include <Library/IoLib.h>
+#include <Library/TimerLib.h>
 #include <Library/CruLib.h>
 #include <Library/GpioLib.h>
+#include <Library/I2cLib.h>
 #include <Library/MultiPhyLib.h>
+#include <Library/OtpLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseCryptLib.h>
 #include <Protocol/ArmScmi.h>
 #include <Protocol/ArmScmiClockProtocol.h>
 
+#include <IndustryStandard/Rk356x.h>
+#include <IndustryStandard/Rk356xCru.h>
+
+#include "EthernetPhy.h"
+
+/*
+ * GMAC registers
+ */
+#define GMAC1_MAC_ADDRESS0_LOW  (GMAC1_BASE + 0x0304)
+#define GMAC1_MAC_ADDRESS0_HIGH (GMAC1_BASE + 0x0300)
+
+#define GRF_MAC1_CON0           (SYS_GRF + 0x0388)
+#define  CLK_RX_DL_CFG_SHIFT    8
+#define  CLK_TX_DL_CFG_SHIFT    0
+#define GRF_MAC1_CON1           (SYS_GRF + 0x038C)
+#define  PHY_INTF_SEL_SHIFT     4
+#define  PHY_INTF_SEL_MASK      (0x7U << PHY_INTF_SEL_SHIFT)
+#define  PHY_INTF_SEL_RGMII     (1U << PHY_INTF_SEL_SHIFT)
+#define  FLOWCTRL               BIT3
+#define  MAC_SPEED              BIT2
+#define  RXCLK_DLY_ENA          BIT1
+#define  TXCLK_DLY_ENA          BIT0
+
+#define TX_DELAY                0x30
+#define RX_DELAY                0x10
+
+/*
+ * PMIC registers
+*/
+#define PMIC_I2C_ADDR           0x20
+
+#define PMIC_CHIP_NAME          0xed
+#define PMIC_CHIP_VER           0xee
+#define PMIC_POWER_EN1          0xb2
+#define PMIC_POWER_EN2          0xb3
+#define PMIC_POWER_EN3          0xb4
+#define PMIC_LDO1_ON_VSEL       0xcc
+#define PMIC_LDO9_ON_VSEL       0xdc
+
+/*
+ * CPU_GRF registers
+*/
+#define GRF_CPU_COREPVTPLL_CON0               (CPU_GRF + 0x0010)
+#define  CORE_PVTPLL_RING_LENGTH_SEL_SHIFT    3
+#define  CORE_PVTPLL_RING_LENGTH_SEL_MASK     (0x1FU << CORE_PVTPLL_RING_LENGTH_SEL_SHIFT)
+#define  CORE_PVTPLL_OSC_EN                   BIT1
+#define  CORE_PVTPLL_START                    BIT0
+
+/*
+ * PMU registers
+ */
+#define PMU_NOC_AUTO_CON0                     (PMU_BASE + 0x0070)
+#define PMU_NOC_AUTO_CON1                     (PMU_BASE + 0x0074)
+
+STATIC CONST GPIO_IOMUX_CONFIG mGmac1IomuxConfig[] = {
+  { "gmac1_mdcm0",        3, GPIO_PIN_PC4, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_mdiom0",       3, GPIO_PIN_PC5, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_txd0m0",       3, GPIO_PIN_PB5, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
+  { "gmac1_txd1m0",       3, GPIO_PIN_PB6, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
+  { "gmac1_txenm0",       3, GPIO_PIN_PB7, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxd0m0",       3, GPIO_PIN_PB1, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxd1m0",       3, GPIO_PIN_PB2, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxdvcrsm0",    3, GPIO_PIN_PB3, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxclkm0",      3, GPIO_PIN_PA7, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_txclkm0",      3, GPIO_PIN_PA6, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_1 },
+  { "gmac1_mclkinoutm0",  3, GPIO_PIN_PC0, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxd2m0",       3, GPIO_PIN_PA4, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_rxd3m0",       3, GPIO_PIN_PA5, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+  { "gmac1_txd2m0",       3, GPIO_PIN_PA2, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
+  { "gmac1_txd3m0",       3, GPIO_PIN_PA3, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
+};
 
 STATIC
 EFI_STATUS
@@ -153,6 +229,138 @@ BoardInitSetCpuSpeed (
   return EFI_SUCCESS;
 }
 
+STATIC
+VOID
+BoardInitGmac (
+  VOID
+  )
+{
+  UINT8 OtpData[32];
+  UINT8 Hash[SHA256_DIGEST_SIZE];
+  UINT32 MacLo, MacHi;
+
+  /* Assert reset */
+  CruAssertSoftReset (14, 12);
+
+  /* Configure pins */
+  GpioSetIomuxConfig (mGmac1IomuxConfig, ARRAY_SIZE (mGmac1IomuxConfig));
+
+  /* Setup clocks */
+  MmioWrite32 (CRU_CLKSEL_CON (33), 0x00370004);  // Set rmii1_mode to rgmii mode
+                                                  // Set rgmii1_clk_sel to 125M
+                                                  // Set rmii1_extclk_sel to mac1 clock from IO
+
+  /* Configure GMAC1 */
+  MmioWrite32 (GRF_MAC1_CON0,
+               0x7F7F0000U |
+               (TX_DELAY << CLK_TX_DL_CFG_SHIFT) |
+               (RX_DELAY << CLK_RX_DL_CFG_SHIFT));
+  MmioWrite32 (GRF_MAC1_CON1,
+               ((PHY_INTF_SEL_MASK | TXCLK_DLY_ENA | RXCLK_DLY_ENA) << 16) |
+               PHY_INTF_SEL_RGMII |
+               TXCLK_DLY_ENA |
+               RXCLK_DLY_ENA);
+
+  /* Reset PHY */
+  GpioPinSetDirection (0, GPIO_PIN_PC3, GPIO_PIN_OUTPUT);
+  MicroSecondDelay (1000);
+  GpioPinWrite (0, GPIO_PIN_PC3, 0);
+  MicroSecondDelay (20000);
+  GpioPinWrite (0, GPIO_PIN_PC3, 1);
+  MicroSecondDelay (100000);
+
+  /* Deassert reset */
+  CruDeassertSoftReset (14, 12);
+
+  /* Generate a MAC address from the first 32 bytes in the OTP and write it to GMAC */
+  OtpRead (0x00, sizeof (OtpData), OtpData);
+  Sha256HashAll (OtpData, sizeof (OtpData), Hash);
+  Hash[0] &= 0xFE;
+  Hash[0] |= 0x02;
+  DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
+          Hash[0], Hash[1], Hash[2],
+          Hash[3], Hash[4], Hash[5]));
+  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
+  MacHi = Hash[5] | (Hash[4] << 8);
+  MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
+  MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
+
+  /* Initialize Ethernet PHY */
+  EthernetPhyInit (GMAC1_BASE);
+}
+
+STATIC
+EFI_STATUS
+PmicRead (
+  IN UINT8 Register,
+  OUT UINT8 *Value
+  )
+{
+  return I2cRead (I2C0_BASE, PMIC_I2C_ADDR,
+                  &Register, sizeof (Register),
+                  Value, sizeof (*Value));
+}
+
+STATIC
+EFI_STATUS
+PmicWrite (
+  IN UINT8 Register,
+  IN UINT8 Value
+  )
+{
+  return I2cWrite (I2C0_BASE, PMIC_I2C_ADDR,
+                  &Register, sizeof (Register),
+                  &Value, sizeof (Value));
+}
+
+STATIC
+VOID
+BoardInitPmic (
+  VOID
+  )
+{
+  EFI_STATUS Status;
+  UINT16 ChipName;
+  UINT8 ChipVer;
+  UINT8 Value;
+
+  DEBUG ((DEBUG_INFO, "BOARD: PMIC init\n"));
+
+  GpioPinSetPull (0, GPIO_PIN_PB1, GPIO_PIN_PULL_NONE);
+  GpioPinSetInput (0, GPIO_PIN_PB1, GPIO_PIN_INPUT_SCHMITT);
+  GpioPinSetFunction (0, GPIO_PIN_PB1, 1);
+  GpioPinSetPull (0, GPIO_PIN_PB2, GPIO_PIN_PULL_NONE);
+  GpioPinSetInput (0, GPIO_PIN_PB2, GPIO_PIN_INPUT_SCHMITT);
+  GpioPinSetFunction (0, GPIO_PIN_PB2, 1);
+
+  Status = PmicRead (PMIC_CHIP_NAME, &Value);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Failed to read PMIC chip name! %r\n", Status));
+    ASSERT (FALSE);
+  }
+  ChipName = (UINT16)Value << 4;
+
+  Status = PmicRead (PMIC_CHIP_VER, &Value);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Failed to read PMIC chip version! %r\n", Status));
+    ASSERT (FALSE);
+  }
+  ChipName |= (Value >> 4) & 0xF;
+  ChipVer = Value & 0xF;
+
+  DEBUG ((DEBUG_INFO, "PMIC: Detected RK%03X ver 0x%X\n", ChipName, ChipVer));
+  ASSERT (ChipName == 0x809);
+
+  /* Check LD01 and LD09 are configured correctly. */
+  PmicRead (PMIC_LDO1_ON_VSEL, &Value);
+  ASSERT (Value == 0x0c); /* 0.8V */
+  PmicRead (PMIC_LDO9_ON_VSEL, &Value);
+  ASSERT (Value == 0x30); /* 1.8V */
+
+  /* Enable LDO1 and LDO9 for HDMI */
+  PmicWrite (PMIC_POWER_EN1, 0x11);
+  PmicWrite (PMIC_POWER_EN3, 0x11);
+}
 
 EFI_STATUS
 EFIAPI
@@ -161,8 +369,9 @@ BoardInitDriverEntryPoint (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
+  DEBUG ((DEBUG_INFO, "BOARD: BoardInitDriverEntryPoint() called\n"));
 
-  DEBUG ((DEBUG_INFO, "BoardInitDriverEntryPoint() called\n"));
+  BoardInitPmic ();
 
   /* Set GPIO0 PC0 (WORK_LED) output low to enable LED */
   GpioPinSetDirection (0, GPIO_PIN_PC0, GPIO_PIN_OUTPUT);
@@ -171,12 +380,21 @@ BoardInitDriverEntryPoint (
   /* Update CPU speed */
   BoardInitSetCpuSpeed ();
 
+  /* Enable automatic clock gating */
+  MmioWrite32 (PMU_NOC_AUTO_CON0, 0xFFFFFFFFU);
+  MmioWrite32 (PMU_NOC_AUTO_CON1, 0x000F000FU);
+
   /* Set core_pvtpll ring length */
-  MmioWrite32 (0xFDC30010U, 0x00ff002b);
+  MmioWrite32 (GRF_CPU_COREPVTPLL_CON0,
+               ((CORE_PVTPLL_RING_LENGTH_SEL_MASK | CORE_PVTPLL_OSC_EN | CORE_PVTPLL_START) << 16) |
+               (5U << CORE_PVTPLL_RING_LENGTH_SEL_SHIFT) | CORE_PVTPLL_OSC_EN | CORE_PVTPLL_START);
 
   /* Configure MULTI-PHY 0 and 1 for USB3 mode */
   MultiPhySetMode (0, MULTIPHY_MODE_USB3);
   MultiPhySetMode (1, MULTIPHY_MODE_USB3);
+
+  /* GMAC setup */
+  BoardInitGmac ();
 
   return EFI_SUCCESS;
 }

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.inf
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.inf
@@ -18,10 +18,12 @@
 
 [Sources]
   BoardInitDxe.c
+  EthernetPhy.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  CryptoPkg/CryptoPkg.dec
   ArmPlatformPkg/ArmPlatformPkg.dec
   ArmPkg/ArmPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
@@ -33,15 +35,19 @@
   UefiBootServicesTableLib
   MemoryAllocationLib
   BaseMemoryLib
+  BaseCryptLib
   BaseLib
   UefiLib
   UefiDriverEntryPoint
   DebugLib
   PrintLib
   TimeBaseLib
+  TimerLib
   CruLib
   GpioLib
+  I2cLib
   MultiPhyLib
+  OtpLib
 
 [Protocols]
 

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/EthernetPhy.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/EthernetPhy.c
@@ -1,0 +1,167 @@
+/** @file
+ *
+ *  Board init for the Quartz64 platform
+ *
+ *  Copyright (c) 2021, Jared McNeill <jmcneill@invisible.ca>
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#include <Base.h>
+#include <Library/ArmLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/IoLib.h>
+#include <Library/TimerLib.h>
+#include "EthernetPhy.h"
+
+/* GMAC registers */
+#define	GMAC_MAC_MDIO_ADDRESS			    0x0200
+#define	 GMAC_MAC_MDIO_ADDRESS_PA_SHIFT		21
+#define	 GMAC_MAC_MDIO_ADDRESS_RDA_SHIFT	16
+#define	 GMAC_MAC_MDIO_ADDRESS_CR_SHIFT		8
+#define	 GMAC_MAC_MDIO_ADDRESS_CR_100_150	(1U << GMAC_MAC_MDIO_ADDRESS_CR_SHIFT)
+#define	 GMAC_MAC_MDIO_ADDRESS_GOC_SHIFT	2
+#define	 GMAC_MAC_MDIO_ADDRESS_GOC_READ		(3U << GMAC_MAC_MDIO_ADDRESS_GOC_SHIFT)
+#define	 GMAC_MAC_MDIO_ADDRESS_GOC_WRITE	(1U << GMAC_MAC_MDIO_ADDRESS_GOC_SHIFT)
+#define	 GMAC_MAC_MDIO_ADDRESS_GB		    BIT0
+#define	GMAC_MAC_MDIO_DATA			        0x0204
+
+/* MII registers */
+#define MII_PHYIDR1                         0x02
+#define MII_PHYIDR2                         0x03
+
+/* Motorcomm PHY registers */
+#define	EXT_REG_ADDR			            0x1E
+#define	EXT_REG_DATA			            0x1F
+#define	PHY_CLOCK_GATING_REG		        0x0C
+#define  TX_CLK_DELAY_SEL_SHIFT             4
+#define	 TX_CLK_DELAY_SEL		            (0xFU << TX_CLK_DELAY_SEL_SHIFT)
+#define  CLK_25M_SEL_SHIFT                  1
+#define	 CLK_25M_SEL_MASK	                (0x3U << CLK_25M_SEL_SHIFT)
+#define	 CLK_25M_SEL_125M		            (3U << CLK_25M_SEL_SHIFT)
+#define	 RX_CLK_DELAY_EN		            BIT0
+#define	PHY_SLEEP_CONTROL1_REG		        0x27
+#define	 PLLON_IN_SLP			            BIT14
+
+STATIC
+VOID
+PhyRead (
+    IN EFI_PHYSICAL_ADDRESS GmacBase,
+    IN UINT8 Phy,
+    IN UINT16 Reg,
+    OUT UINT16 *Value
+    )
+{
+    UINT32 Addr;
+    UINTN Retry;
+
+    Addr = GMAC_MAC_MDIO_ADDRESS_CR_100_150 |
+           (Phy << GMAC_MAC_MDIO_ADDRESS_PA_SHIFT) |
+           (Reg << GMAC_MAC_MDIO_ADDRESS_RDA_SHIFT) |
+           GMAC_MAC_MDIO_ADDRESS_GOC_READ |
+           GMAC_MAC_MDIO_ADDRESS_GB;
+    MmioWrite32 (GmacBase + GMAC_MAC_MDIO_ADDRESS, Addr);
+
+    MicroSecondDelay (10000);
+
+    for (Retry = 1000; Retry > 0; Retry--) {
+        Addr = MmioRead32 (GmacBase + GMAC_MAC_MDIO_ADDRESS);
+        if ((Addr & GMAC_MAC_MDIO_ADDRESS_GB) == 0) {
+            *Value = MmioRead32 (GmacBase + GMAC_MAC_MDIO_DATA) & 0xFFFFu;
+            break;
+        }
+        MicroSecondDelay (10);
+    }
+    if (Retry == 0) {
+        DEBUG ((DEBUG_WARN, "MDIO: PHY read timeout!\n"));
+        *Value = 0xFFFFU;
+        ASSERT (FALSE);
+    }
+}
+
+STATIC
+VOID
+PhyWrite (
+    IN EFI_PHYSICAL_ADDRESS GmacBase,
+    IN UINT8 Phy,
+    IN UINT16 Reg,
+    IN UINT16 Value
+    )
+{
+    UINT32 Addr;
+    UINTN Retry;
+
+    MmioWrite32 (GmacBase + GMAC_MAC_MDIO_DATA, Value);
+
+    Addr = GMAC_MAC_MDIO_ADDRESS_CR_100_150 |
+           (Phy << GMAC_MAC_MDIO_ADDRESS_PA_SHIFT) |
+           (Reg << GMAC_MAC_MDIO_ADDRESS_RDA_SHIFT) |
+           GMAC_MAC_MDIO_ADDRESS_GOC_WRITE |
+           GMAC_MAC_MDIO_ADDRESS_GB;
+    MmioWrite32 (GmacBase + GMAC_MAC_MDIO_ADDRESS, Addr);
+
+    MicroSecondDelay (10000);
+
+    for (Retry = 1000; Retry > 0; Retry--) {
+        Addr = MmioRead32 (GmacBase + GMAC_MAC_MDIO_ADDRESS);
+        if ((Addr & GMAC_MAC_MDIO_ADDRESS_GB) == 0) {
+            break;
+        }
+        MicroSecondDelay (10);
+    }
+    if (Retry == 0) {
+        DEBUG ((DEBUG_WARN, "MDIO: PHY write timeout!\n"));
+        ASSERT (FALSE);
+    }
+}
+
+STATIC
+VOID
+MotorcommPhyInit (
+    IN EFI_PHYSICAL_ADDRESS GmacBase
+    )
+{
+    UINT16 OldAddr;
+    UINT16 Data;
+
+    PhyRead (GmacBase, 0, EXT_REG_ADDR, &OldAddr);
+
+    PhyWrite (GmacBase, 0, EXT_REG_ADDR, PHY_CLOCK_GATING_REG);
+    PhyRead (GmacBase, 0, EXT_REG_DATA, &Data);
+    Data &= ~CLK_25M_SEL_MASK;
+    Data |= CLK_25M_SEL_125M;
+    Data &= ~RX_CLK_DELAY_EN;
+    Data &= ~TX_CLK_DELAY_SEL;
+    Data |= (2U << TX_CLK_DELAY_SEL_SHIFT);
+    PhyWrite (GmacBase, 0, EXT_REG_DATA, Data);
+
+    PhyWrite (GmacBase, 0, EXT_REG_ADDR, PHY_SLEEP_CONTROL1_REG);
+    PhyRead (GmacBase, 0, EXT_REG_DATA, &Data);
+    Data |= PLLON_IN_SLP;
+    PhyWrite (GmacBase, 0, EXT_REG_DATA, Data);
+
+    PhyWrite (GmacBase, 0, EXT_REG_ADDR, OldAddr);
+}
+
+VOID
+EthernetPhyInit (
+    IN EFI_PHYSICAL_ADDRESS GmacBase
+    )
+{
+    UINT16 PhyId[2];
+
+    PhyRead (GmacBase, 0, MII_PHYIDR1, &PhyId[0]);
+    PhyRead (GmacBase, 0, MII_PHYIDR2, &PhyId[1]);
+
+
+    if (PhyId[0] == 0x0000 && PhyId[1] == 0x010A) {
+        DEBUG ((DEBUG_INFO, "MDIO: Found Motorcomm YT8511 GbE PHY\n"));
+        MotorcommPhyInit (GmacBase);
+    } else {
+        DEBUG ((DEBUG_INFO, "MDIO: Unknown PHY ID %04X %04X\n", PhyId[0], PhyId[1]));
+    }
+}

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/EthernetPhy.h
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/EthernetPhy.h
@@ -1,0 +1,17 @@
+/** @file
+ *
+ *  Copyright (c) 2021, Jared McNeill <jmcneill@invisible.ca>
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#ifndef ETHERNETPHY_H__
+#define ETHERNETPHY_H__
+
+VOID
+EthernetPhyInit (
+    IN EFI_PHYSICAL_ADDRESS GmacBase
+    );
+
+#endif /* ETHERNETPHY_H__ */

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -1000,7 +1000,7 @@ PhyMemArrayInfoUpdateSmbiosType16 (
  //  - Type 17 VolatileSize in Bytes
  //
 
-  mMemDevInfoType17.Size = mMemorySize / (1024 * 1024);;
+  mMemDevInfoType17.Size = mMemorySize / (1024 * 1024);
 
   mPhyMemArrayInfoType16.MaximumCapacity = mMemDevInfoType17.Size * 1024; // Size in KB
   mMemDevInfoType17.VolatileSize = MultU64x32 (mMemDevInfoType17.Size, 1024 * 1024);  // Size in Bytes

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
@@ -65,4 +65,3 @@
   gRk356xTokenSpaceGuid.PcdCpuSpeed
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString
-

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -118,6 +118,7 @@
   # Rockchip SoC libraries
   CruLib|Silicon/Rockchip/Rk356x/Library/CruLib/CruLib.inf
   GpioLib|Silicon/Rockchip/Rk356x/Library/GpioLib/GpioLib.inf
+  I2cLib|Silicon/Rockchip/Rk356x/Library/I2cLib/I2cLib.inf
   MultiPhyLib|Silicon/Rockchip/Rk356x/Library/MultiPhyLib/MultiPhyLib.inf
   OtpLib|Silicon/Rockchip/Rk356x/Library/OtpLib/OtpLib.inf
   SdramLib|Silicon/Rockchip/Rk356x/Library/SdramLib/SdramLib.inf


### PR DESCRIPTION
Since SOQuartz was copied from Quartz64, a few things have changed in
there.  Like the Quartz64, it also has a YT8511C PHY with the same
GPIO pins for reset and TX/RX delays.  It might be a sensible idea to
deduplicate the Phy init code.  The PMIC on the other hand is the RK809
as implemented on the ROC-PC-RK3566, so copy that code to make sure that
the PMIC is turned on fully to make HDMI work.