### PR TITLE
RK356x: make USB controllers configurable

### DIFF
--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
@@ -429,6 +429,16 @@
   gRk356xTokenSpaceGuid.PcdCpuName|"Rockchip RK3566 (Cortex-A55)"
 
   #
+  # USB support
+  #
+  gRk356xTokenSpaceGuid.PcdOhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdOhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc1Status|0xF
+
+  #
   # PCI support
   #
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0x0000000300000000

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/ROC-RK3568-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/ROC-RK3568-PC.dsc
@@ -428,6 +428,16 @@
   gRk356xTokenSpaceGuid.PcdCpuName|"Rockchip RK3568 (Cortex-A55)"
 
   #
+  # USB support
+  #
+  gRk356xTokenSpaceGuid.PcdOhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdOhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc1Status|0xF
+
+  #
   # PCI support
   #
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0x0000000300000000

--- a/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
+++ b/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
@@ -429,6 +429,16 @@
   gRk356xTokenSpaceGuid.PcdCpuName|"Rockchip RK3566 (Cortex-A55)"
 
   #
+  # USB support
+  #
+  gRk356xTokenSpaceGuid.PcdOhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdOhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdEhc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc0Status|0xF
+  gRk356xTokenSpaceGuid.PcdXhc1Status|0xF
+
+  #
   # PCI support
   #
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0x0000000300000000

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -428,6 +428,11 @@
   gRk356xTokenSpaceGuid.PcdCpuName|"Rockchip RK3566 (Cortex-A55)"
 
   #
+  # Only a single USB controller is brought out
+  #
+  gRk356xTokenSpaceGuid.PcdXhc0Status|0xF
+
+  #
   # PCI support
   #
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0x0000000300000000

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Quartz64.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Quartz64.inf
@@ -52,9 +52,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
 
-  gRk356xTokenSpaceGuid.PcdUsb2BaseAddr
-  gRk356xTokenSpaceGuid.PcdUsb2Size
-  gRk356xTokenSpaceGuid.PcdNumUsb2Controller
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
 
   gRk356xTokenSpaceGuid.PcdMshc1Status
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC.inf
@@ -52,9 +52,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
 
-  gRk356xTokenSpaceGuid.PcdUsb2BaseAddr
-  gRk356xTokenSpaceGuid.PcdUsb2Size
-  gRk356xTokenSpaceGuid.PcdNumUsb2Controller
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
 
   gRk356xTokenSpaceGuid.PcdMshc1Status
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3568-PC.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3568-PC.inf
@@ -52,9 +52,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
 
-  gRk356xTokenSpaceGuid.PcdUsb2BaseAddr
-  gRk356xTokenSpaceGuid.PcdUsb2Size
-  gRk356xTokenSpaceGuid.PcdNumUsb2Controller
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
 
   gRk356xTokenSpaceGuid.PcdMshc1Status
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/SOQuartz.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/SOQuartz.inf
@@ -52,9 +52,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
 
-  gRk356xTokenSpaceGuid.PcdUsb2BaseAddr
-  gRk356xTokenSpaceGuid.PcdUsb2Size
-  gRk356xTokenSpaceGuid.PcdNumUsb2Controller
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
 
   gRk356xTokenSpaceGuid.PcdMshc1Status
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Usb2.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Usb2.asl
@@ -30,6 +30,8 @@ Device (OHC0) {
         Return (RBUF)
     }
 
+    Name (_STA, FixedPcdGet8(PcdOhc0Status))
+
     Device (RHUB) {
         Name (_ADR, 0)
         Device (PRT1) {
@@ -70,6 +72,8 @@ Device (EHC0) {
         })
         Return (RBUF)
     }
+
+    Name (_STA, FixedPcdGet8(PcdEhc0Status))
 
     Device (RHUB) {
         Name (_ADR, 0)
@@ -120,6 +124,8 @@ Device (OHC1) {
         Return (RBUF)
     }
 
+    Name (_STA, FixedPcdGet8(PcdOhc1Status))
+
     Device (RHUB) {
         Name (_ADR, 0)
         Device (PRT1) {
@@ -160,6 +166,8 @@ Device (EHC1) {
         })
         Return (RBUF)
     }
+
+    Name (_STA, FixedPcdGet8(PcdEhc1Status))
 
     Device (RHUB) {
         Name (_ADR, 0)

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Usb3.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Usb3.asl
@@ -21,6 +21,8 @@ Device (XHC0) {
         })
         Return (RBUF)
     }
+
+    Name (_STA, FixedPcdGet8(PcdXhc0Status))
 } // XHC0
 
 // USB XHCI Host Controller
@@ -36,4 +38,6 @@ Device (XHC1) {
         })
         Return (RBUF)
     }
+
+    Name (_STA, FixedPcdGet8(PcdXhc1Status))
 } // XHC0

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/UsbHcdInitDxe/UsbHcd.c
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/UsbHcdInitDxe/UsbHcd.c
@@ -272,6 +272,11 @@ UsbEndOfDxeCallback (
 
   /* Register USB3 controllers */
   for (Index = 0; Index < NumUsb3Controller; Index++) {
+    if ((Index == 0 && FixedPcdGet8(PcdXhc0Status) == 0x0) ||
+        (Index == 1 && FixedPcdGet8(PcdXhc1Status) == 0x0)) {
+      continue;
+    }
+
     XhciControllerAddr = PcdGet64 (PcdUsb3BaseAddr) +
                           (Index * PcdGet32 (PcdUsb3Size));
 
@@ -292,9 +297,13 @@ UsbEndOfDxeCallback (
 
   /* Register USB2 controllers */
   for (Index = 0; Index < NumUsb2Controller; Index++) {
+    if ((Index == 0 && FixedPcdGet8(PcdEhc0Status) == 0x0) ||
+        (Index == 1 && FixedPcdGet8(PcdEhc1Status) == 0x0)) {
+      continue;
+    }
+
     EhciControllerAddr = PcdGet64 (PcdUsb2BaseAddr) +
                           (Index * PcdGet32 (PcdUsb2Size));
-    OhciControllerAddr = EhciControllerAddr + 0x10000;
 
     Status = RegisterNonDiscoverableMmioDevice (
                NonDiscoverableDeviceTypeEhci,
@@ -309,6 +318,17 @@ UsbEndOfDxeCallback (
       DEBUG ((DEBUG_ERROR, "Failed to register EHCI device 0x%x, error 0x%r \n",
         EhciControllerAddr, Status));
     }
+  }
+
+  for (Index = 0; Index < NumUsb2Controller; Index++) {
+    if ((Index == 0 && FixedPcdGet8(PcdOhc0Status) == 0x0) ||
+        (Index == 1 && FixedPcdGet8(PcdOhc1Status) == 0x0)) {
+      continue;
+    }
+
+    OhciControllerAddr = PcdGet64 (PcdUsb2BaseAddr) +
+                          (Index * PcdGet32 (PcdUsb2Size)) +
+                          0x10000;
 
     Status = RegisterNonDiscoverableMmioDevice (
                NonDiscoverableDeviceTypeOhci,

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/UsbHcdInitDxe/UsbHcd.inf
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Drivers/UsbHcdInitDxe/UsbHcd.inf
@@ -41,6 +41,12 @@
   gRk356xTokenSpaceGuid.PcdUsb3BaseAddr
   gRk356xTokenSpaceGuid.PcdUsb3Size
   gRk356xTokenSpaceGuid.PcdUsbPhyGrfBaseAddr
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Rk356x.dec
@@ -27,6 +27,12 @@
   gRk356xTokenSpaceGuid.PcdUsb3Size|0x400000|UINT32|0x00000004
   gRk356xTokenSpaceGuid.PcdNumUsb3Controller|2|UINT32|0x00000005
   gRk356xTokenSpaceGuid.PcdUsbPhyGrfBaseAddr|0xFDCA0000|UINT64|0x00000006
+  gRk356xTokenSpaceGuid.PcdOhc0Status|0x0|UINT8|0x00000007
+  gRk356xTokenSpaceGuid.PcdOhc1Status|0x0|UINT8|0x00000008
+  gRk356xTokenSpaceGuid.PcdEhc0Status|0x0|UINT8|0x00000009
+  gRk356xTokenSpaceGuid.PcdEhc1Status|0x0|UINT8|0x0000000a
+  gRk356xTokenSpaceGuid.PcdXhc0Status|0x0|UINT8|0x0000000b
+  gRk356xTokenSpaceGuid.PcdXhc1Status|0x0|UINT8|0x0000000c
   # Pcds for MSHC
   gRk356xTokenSpaceGuid.PcdMshcDxeBaseAddress|0xFE2B0000|UINT32|0x00000010
   gRk356xTokenSpaceGuid.PcdMshcDxeMaxClockFreqInHz|50000000|UINT32|0x00000011


### PR DESCRIPTION
The SOQuartz only brings out a single USB controller, xHCI0.  So far we
have always enabled all of them, but that needs to be configurable per
board.