### PR TITLE
SOQuartz: initialize WiFi

### DIFF
--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -102,6 +102,16 @@ STATIC CONST GPIO_IOMUX_CONFIG mGmac1IomuxConfig[] = {
   { "gmac1_txd3m0",       3, GPIO_PIN_PA3, 3, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_2 },
 };
 
+STATIC CONST GPIO_IOMUX_CONFIG mSdmmc1IomuxConfig[] = {
+  { "sdmmc1_d0",          2, GPIO_PIN_PA3, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d1",          2, GPIO_PIN_PA4, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d2",          2, GPIO_PIN_PA5, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_d3",          2, GPIO_PIN_PA6, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_cmd",         2, GPIO_PIN_PA7, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "sdmmc1_clk",         2, GPIO_PIN_PB0, 1, GPIO_PIN_PULL_UP,   GPIO_PIN_DRIVE_2 },
+  { "wifi_reg_on",        2, GPIO_PIN_PC2, 0, GPIO_PIN_PULL_NONE, GPIO_PIN_DRIVE_DEFAULT },
+};
+
 STATIC
 EFI_STATUS
 BoardInitSetCpuSpeed (
@@ -362,6 +372,28 @@ BoardInitPmic (
   PmicWrite (PMIC_POWER_EN3, 0x11);
 }
 
+STATIC
+VOID
+BoardInitWiFi (
+  VOID
+  )
+{
+  DEBUG ((DEBUG_INFO, "BOARD: WiFi init\n"));
+
+  CruSetSdmmcClockRate (1, 100000000UL);
+
+  /* Configure pins */
+  GpioSetIomuxConfig (mSdmmc1IomuxConfig, ARRAY_SIZE (mSdmmc1IomuxConfig));
+
+  /* Set GPIO2 PC2 (WIFI_REG_ON) output high to enable WiFi */
+  GpioPinSetDirection (2, GPIO_PIN_PC2, GPIO_PIN_OUTPUT);
+  MicroSecondDelay (1000);
+  GpioPinWrite (2, GPIO_PIN_PC2, FALSE);
+  MicroSecondDelay (500000);
+  GpioPinWrite (2, GPIO_PIN_PC2, TRUE);
+  MicroSecondDelay (100000);
+}
+
 EFI_STATUS
 EFIAPI
 BoardInitDriverEntryPoint (
@@ -395,6 +427,9 @@ BoardInitDriverEntryPoint (
 
   /* GMAC setup */
   BoardInitGmac ();
+
+  /* WiFi setup */
+  BoardInitWiFi ();
 
   return EFI_SUCCESS;
 }

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -451,6 +451,13 @@
   gRk356xTokenSpaceGuid.PcdPcieResetGpioBank|1
   gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|10
 
+  #
+  # The SOQuartz has a WiFi card on the second MSHC
+  #
+  gRk356xTokenSpaceGuid.PcdMshc1Status|0xF
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq|TRUE
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable|TRUE
+
 [PcdsDynamicHii.common.DEFAULT]
 
   #


### PR DESCRIPTION
Like the ROC-RK3566-PC, the SOQuartz has a Broadcom/Cypress WiFi
Chip on the second SD/MMC controller.