### PR TITLE
Rk356x: comment cleanup

### DIFF
--- a/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
+++ b/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
@@ -459,7 +459,7 @@
   gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|22
 
   #
-  # The Quartz64 board has inverted polarity for the PWREN pin on the SD card slot
+  # This board has inverted polarity for the PWREN pin on the SD card slot
   #
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|TRUE
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|TRUE

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -452,7 +452,7 @@
   gRk356xTokenSpaceGuid.PcdPcieResetGpioPin|10
 
   #
-  # The SOQuartz has a WiFi card on the second MSHC
+  # This module has a WiFi card on the second MSHC
   #
   gRk356xTokenSpaceGuid.PcdMshc1Status|0xF
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq|TRUE

--- a/edk2-rockchip/Platform/Radxa/CM3/CM3.dsc
+++ b/edk2-rockchip/Platform/Radxa/CM3/CM3.dsc
@@ -447,13 +447,13 @@
   gRk356xTokenSpaceGuid.PcdPciePowerGpioPin|27
 
   #
-  # The RADXA CM3 has inverted polarity for the PWREN pin on the SD card slot
+  # This module has inverted polarity for the PWREN pin on the SD card slot
   #
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnUsed|TRUE
   gRk356xTokenSpaceGuid.PcdMshcDxePwrEnInverted|TRUE
 
   #
-  # The SOQuartz has a WiFi card on the second MSHC
+  # This module has a WiFi card on the second MSHC
   #
   gRk356xTokenSpaceGuid.PcdMshc1Status|0xF
   gRk356xTokenSpaceGuid.PcdMshc1SdioIrq|TRUE

--- a/edk2-rockchip/Platform/Radxa/CM3/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Radxa/CM3/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -265,7 +265,7 @@ BoardInitGmac (
                RXCLK_DLY_ENA);
 
   /* Reset PHY */
-  GpioPinSetDirection (4, GPIO_PIN_PC2, GPIO_PIN_OUTPUT);	/* XXX from furkan */
+  GpioPinSetDirection (4, GPIO_PIN_PC2, GPIO_PIN_OUTPUT);
   MicroSecondDelay (1000);
   GpioPinWrite (4, GPIO_PIN_PC2, 0);
   MicroSecondDelay (20000);


### PR DESCRIPTION
Remove an XXX, and stop mentioning the platform itself, as when this
config is duplicated it's easy to forget to update the name.