### PR TITLE
Fix the build by updating to the latest stable edk2 release

### DIFF
--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
@@ -534,6 +534,7 @@
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   }
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/ROC-RK3568-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/ROC-RK3568-PC.dsc
@@ -535,6 +535,7 @@
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   }
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf

--- a/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
+++ b/edk2-rockchip/Platform/Pine64/Quartz64/Quartz64.dsc
@@ -529,6 +529,7 @@
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   }
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/SOQuartz.dsc
@@ -521,6 +521,7 @@
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   }
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf

--- a/edk2-rockchip/Platform/Radxa/CM3/CM3.dsc
+++ b/edk2-rockchip/Platform/Radxa/CM3/CM3.dsc
@@ -530,6 +530,7 @@
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+      VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   }
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf


### PR DESCRIPTION
Hey there!

I wasn't able to build this repo as-is, since recent versions of GCC add some new warnings that the version of EDK2 we're pinned to runs afoul of. This PR bumps up the version + makes a tiny dependency change to each platform to deal with the new EDK2 version.

I have not thoroughly tested this, but I figure having a working build seems important?