### PR TITLE
RK356x: combine Gmac interrupts into single statement

### DIFF
--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Gmac.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/Gmac.asl
@@ -29,8 +29,7 @@ Device (MAC0) {
     Method (_CRS, 0x0, Serialized) {
         Name (RBUF, ResourceTemplate() {
             Memory32Fixed (ReadWrite, 0xFE2A0000, 0x10000)
-            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 59 }
-            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 56 }
+            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 59, 56 }
         })
         Return (RBUF)
     }
@@ -66,8 +65,7 @@ Device (MAC1) {
     Method (_CRS, 0x0, Serialized) {
         Name (RBUF, ResourceTemplate() {
             Memory32Fixed (ReadWrite, 0xFE010000, 0x10000)
-            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 64 }
-            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 61 }
+            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 64, 61 }
         })
         Return (RBUF)
     }


### PR DESCRIPTION
Hi,

I was playing around with the Gmac on Linux today and have seen some rather interesting behaviour.
First of all: I'm not very well informed about ACPI internals (yet), so I have no real idea what I'm doing here.

It seems that Linux can't understand the 2 separate Interrupt() resource templates in the Gmac.asl file.
As soon as I've combined these into a single statement, the kernel would resolve the 2 interrupts "macirq", "eth_wake_irq" successfully.

I'm not sure if this change has negative impact on other OSes.

As far as Linux is concerned, the current stmmac driver is not well equipped to handle configuration via ACPI.
There's an open patchset from late last year, which tried to implement probing via the fwnode interface:
https://lore.kernel.org/netdev/Y0VkeSxv9IkJPHJj@lunn.ch/T/
which should allow for configuration via ACPI/fwnode, but as far as I can tell, no such change was ever merged upstream.

What do you think?