### PR TITLE
BoardInitGmac: Fix byte-swapped MAC address

### DIFF
--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -167,8 +167,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 }

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3568-PC/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -240,8 +240,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: GMAC0 MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC0_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC0_MAC_ADDRESS0_HIGH, MacHi);
 
@@ -249,8 +249,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: GMAC1 MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 

--- a/edk2-rockchip/Platform/OrangePi/OrangePi3B/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi3B/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -169,8 +169,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 

--- a/edk2-rockchip/Platform/Pine64/Quartz64/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Pine64/Quartz64/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -159,8 +159,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 

--- a/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Pine64/SOQuartz/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -162,8 +162,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 

--- a/edk2-rockchip/Platform/Radxa/CM3/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Radxa/CM3/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -154,8 +154,8 @@ BoardInitGmac (
   DEBUG ((DEBUG_INFO, "BOARD: MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
           Hash[0], Hash[1], Hash[2],
           Hash[3], Hash[4], Hash[5]));
-  MacLo = Hash[3] | (Hash[2] << 8) | (Hash[1] << 16) | (Hash[0] << 24);
-  MacHi = Hash[5] | (Hash[4] << 8);
+  MacLo = Hash[0] | (Hash[1] << 8) | (Hash[2] << 16) | (Hash[3] << 24);
+  MacHi = Hash[4] | (Hash[5] << 8);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_LOW, MacLo);
   MmioWrite32 (GMAC1_MAC_ADDRESS0_HIGH, MacHi);
 }


### PR DESCRIPTION
GMAC[01]_MAC_ADDRESS0_{LOW,HIGH} were written in MSB, but they should be in LSB.

See also the fix for NetBSD eqos(4) driver:
https://github.com/NetBSD/src/commit/8c816b8cdf3a6a6a880c3b5ad5564fa7bfdd1d1a

Tested for Quartz64. For other boards, compile-test only.