### PR TITLE
Avoid lockup in PCIe setup when the M.2 header is not populated

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
@@ -347,7 +347,7 @@ InitializePciHost (
 
   if (PCIE_SEGMENT == PCIE_SEGMENT_PCIE30X1 || PCIE_SEGMENT == PCIE_SEGMENT_PCIE30X2) {
     /* Configure PCIe 3.0 PHY */
-    Pcie30PhyInit ();
+    EFI_STATUS Status; Status = Pcie30PhyInit (); if (EFI_ERROR(Status)) { return Status; }
   } else {
     /* Configure PCIe 2.0 PHY */
     MultiPhySetMode (2, MULTIPHY_MODE_PCIE);

--- a/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
+++ b/edk2-rockchip/Silicon/Rockchip/Rk356x/Library/Rk356xPciHostBridgeLib/PciHostBridgeInit.c
@@ -347,7 +347,11 @@ InitializePciHost (
 
   if (PCIE_SEGMENT == PCIE_SEGMENT_PCIE30X1 || PCIE_SEGMENT == PCIE_SEGMENT_PCIE30X2) {
     /* Configure PCIe 3.0 PHY */
-    EFI_STATUS Status; Status = Pcie30PhyInit (); if (EFI_ERROR(Status)) { return Status; }
+    EFI_STATUS Status;
+    Status = Pcie30PhyInit ();
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
   } else {
     /* Configure PCIe 2.0 PHY */
     MultiPhySetMode (2, MULTIPHY_MODE_PCIE);


### PR DESCRIPTION
Pcie30PhyInit () may fail e.g. on boards w/o the M.2 header populated.
Abort driver startup in this case and return with an early error.