### PR TITLE
[ROC-RK3566-PC] ACPI-only GMAC1 for native Linux stmmac

### DIFF
--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.c
@@ -49,8 +49,8 @@
 #define  RXCLK_DLY_ENA          BIT1
 #define  TXCLK_DLY_ENA          BIT0
 
-#define TX_DELAY                0x4E
-#define RX_DELAY                0x2C
+#define TX_DELAY                0x4F
+#define RX_DELAY                0x24
 
 /*
  * PMIC registers

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.dsc
@@ -35,6 +35,7 @@
 [Components.common]
   Platform/Firefly/ROC-RK3566-PC/Drivers/BoardInitDxe/BoardInitDxe.inf
   MdeModulePkg/Logo/LogoDxe.inf
+  Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC-AcpiOnly.inf
 
 [PcdsFixedAtBuild.common]
   #
@@ -58,8 +59,9 @@
   gRk356xTokenSpaceGuid.PcdXhc1Status|0xF
 
   #
-  # Ethernet support
+  # Ethernet: stock Gmac.asl in DSDT (ACPI+DT). ACPI-only uses ROC-RK3566-PC-AcpiOnly.inf.
   #
+  gRk356xTokenSpaceGuid.PcdMac0Status|0
   gRk356xTokenSpaceGuid.PcdMac1Status|0xF
 
   #

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.fdf.inc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3566-PC/ROC-RK3566-PC.fdf.inc
@@ -21,6 +21,7 @@ INF MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
 INF MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
 INF Platform/Rockchip/Rk356x/Drivers/PlatformAcpiDxe/PlatformAcpiDxe.inf
 INF RuleOverride = ACPITABLE Platform/Rockchip/Rk356x/AcpiTables/$(PLATFORM_NAME).inf
+INF RuleOverride = ACPITABLE Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC-AcpiOnly.inf
 
 #
 # SMBIOS Support

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC-AcpiOnly.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC-AcpiOnly.inf
@@ -1,0 +1,74 @@
+## @file
+#
+#  ACPI tables for ROC-RK3566-PC ACPI-only boot (enriched GMAC1 DSDT).
+#  PlatformAcpiDxe installs this FFS when PcdSystemTableMode is ACPI-only.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = Rk356xAcpiTablesAcpiOnly
+  FILE_GUID                      = 7C4E9A21-6B3D-4F8E-9C12-A0C13566AC01
+  MODULE_TYPE                    = USER_DEFINED
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  ROC-RK3566-PC/Dsdt-AcpiOnly.asl
+  Dbg2.aslc
+  Fadt.aslc
+  Gtdt.aslc
+  Madt.aslc
+  Mcfg.aslc
+  Spcr.aslc
+
+[Packages]
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  ArmPkg/ArmPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  Platform/Rockchip/Rk356x/Rk356x.dec
+  Silicon/Rockchip/Rk356x/Rk356x.dec
+
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdGicDistributorBase
+  gArmTokenSpaceGuid.PcdGicRedistributorsBase
+
+  gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemRevision
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
+
+  gRk356xTokenSpaceGuid.PcdOhc0Status
+  gRk356xTokenSpaceGuid.PcdOhc1Status
+  gRk356xTokenSpaceGuid.PcdEhc0Status
+  gRk356xTokenSpaceGuid.PcdEhc1Status
+  gRk356xTokenSpaceGuid.PcdXhc0Status
+  gRk356xTokenSpaceGuid.PcdXhc1Status
+  gRk356xTokenSpaceGuid.PcdMac0Status
+  gRk356xTokenSpaceGuid.PcdMac1Status
+  gRk356xTokenSpaceGuid.PcdUart3Status
+  gRk356xTokenSpaceGuid.PcdUart4Status
+
+  gRk356xTokenSpaceGuid.PcdMshc1Status
+  gRk356xTokenSpaceGuid.PcdMshc1SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc1NonRemovable
+  gRk356xTokenSpaceGuid.PcdMshc2Status
+  gRk356xTokenSpaceGuid.PcdMshc2SdioIrq
+  gRk356xTokenSpaceGuid.PcdMshc2NonRemovable
+
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+
+[BuildOptions]
+  GCC:*_*_*_ASL_FLAGS       = -vw3133 -vw3150

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC/Dsdt-AcpiOnly.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC/Dsdt-AcpiOnly.asl
@@ -1,0 +1,31 @@
+/** @file
+*  DSDT for Firefly ROC-RK3566-PC (ACPI-only / no devicetree).
+*
+*  Installed from FV when PcdSystemTableMode is ACPI-only; see
+*  ROC-RK3566-PC-AcpiOnly.inf and PlatformAcpiDxe.
+*
+*  Copyright (c) 2022, Jared McNeill <jmcneill@invisible.ca>
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <IndustryStandard/Acpi60.h>
+
+DefinitionBlock ("DsdtTable.aml", "DSDT",
+                 EFI_ACPI_6_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_REVISION,
+                 "RKCP  ", "RK356X  ", FixedPcdGet32 (PcdAcpiDefaultOemRevision)) {
+  Scope (_SB) {
+
+    include ("Cpu.asl")
+    include ("Tsadc.asl")
+    include ("Uart.asl")
+    include ("Wdt.asl")
+    include ("Usb2.asl")
+    include ("Usb3.asl")
+    include ("ROC-RK3566-PC/Gmac-MAC1.asl")
+    include ("Mshc.asl")
+    include ("Emmc.asl")
+    include ("Pcie2x1.asl")
+
+  } // Scope (_SB)
+}

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC/Gmac-MAC1.asl
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/AcpiTables/ROC-RK3566-PC/Gmac-MAC1.asl
@@ -1,0 +1,83 @@
+/** @file
+ *  ROC-RK3566-PC GMAC1 for ACPI-only Linux (PRP0001).
+ *
+ *  Used only from Dsdt-AcpiOnly.asl (FV ROC-RK3566-PC-AcpiOnly.inf). ACPI+DT boots
+ *  use the stock Dsdt.asl with Gmac.asl instead (see PlatformAcpiDxe).
+ *
+ *  PHY: RTL8211F-class RGMII at MDIO address 0 (matches rk3566-roc-pc.dts).
+ *  BoardInitDxe resets GPIO0 PB7 and programs GRF; Linux uses phylink + MDIO.
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ **/
+
+#include <IndustryStandard/Acpi60.h>
+
+// Gigabit Media Access Controller (GMAC1) @ 0xFE010000
+Device (MAC1) {
+    Name (_HID, "PRP0001")
+    Name (_UID, 3)
+    Name (_CCA, Zero)
+
+    Name (_STA, FixedPcdGet8 (PcdMac1Status))
+
+    Name (_DSD, Package () {
+        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+        Package () {
+            Package () { "compatible", Package () {
+                "rockchip,rk3568-gmac",
+                "snps,dwmac-4.20a",
+                "snps,dwmac"
+            } },
+            Package () { "phy-mode", "rgmii" },
+            Package (2) { "phy-handle", \_SB.MAC1.PHY0 },
+            Package () { "clock_in_out", "input" },
+            Package () { "tx_delay", 0x4F },
+            Package () { "rx_delay", 0x24 },
+            //
+            // GRF syscon physical base (see rk356x.dtsi grf@fdc60000).
+            // Linux maps this when devicetree is absent.
+            //
+            Package () { "rockchip,grf", 0xFDC60000 },
+            //
+            // BoardInitDxe already programs clocks, pinmux, PHY reset, and GRF.
+            //
+            Package () { "rockchip,uefi-initialized", 1 },
+            Package () { "interrupt-names", Package () { "macirq", "eth_wake_irq" } },
+            Package () { "snps,mixed-burst", 1 },
+            Package () { "snps,tso", 1 },
+            Package () { "snps,axi-config", "AXIC" },
+        }
+    })
+
+    Method (_CRS, 0x0, Serialized) {
+        Name (RBUF, ResourceTemplate() {
+            Memory32Fixed (ReadWrite, 0xFE010000, 0x10000)
+            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 64, 61 }
+        })
+        Return (RBUF)
+    }
+
+    Name (AXIC, Package () {
+        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+        Package () {
+            Package () { "snps,wr_osr_lmt", 4 },
+            Package () { "snps,rd_osr_lmt", 8 },
+            Package () { "snps,blen", Package () { 0, 0, 0, 0, 16, 8, 4 } },
+        }
+    })
+
+    //
+    // MDIO PHY @ address 0 — same as &mdio1 { ethernet-phy@0 } in rk3566-roc-pc.dts.
+    //
+    Device (PHY0) {
+        Name (_ADR, Zero)
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () { "compatible", Package () {
+                    "ethernet-phy-ieee802.3-c22"
+                } },
+            }
+        })
+    }
+}

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/Drivers/PlatformAcpiDxe/PlatformAcpiDxe.c
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/Drivers/PlatformAcpiDxe/PlatformAcpiDxe.c
@@ -13,14 +13,57 @@
 #include <Library/DebugLib.h>
 #include <Library/DxeServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/AcpiLib.h>
 #include <ConfigVars.h>
 
-STATIC CONST EFI_GUID mAcpiTableFile = {
+/** ACPI tables built from Platform/Rockchip/Rk356x/AcpiTables/$(PLATFORM_NAME).inf */
+STATIC CONST EFI_GUID  mAcpiTableFile = {
   0x0FBE0D20, 0x3528, 0x4F07, { 0x83, 0x8B, 0x9A, 0x71, 0x1C, 0x62, 0x65, 0x4f }
 };
+
+/** ROC-RK3566-PC ACPI-only tables (Dsdt-AcpiOnly.asl / Gmac-MAC1.asl). */
+STATIC CONST EFI_GUID  mRocRk3566PcAcpiOnlyTableFile = {
+  0x7C4E9A21, 0x6B3D, 0x4F8E, { 0x9C, 0x12, 0xA0, 0xC1, 0x35, 0x66, 0xAC, 0x01 }
+};
+
+STATIC CONST CHAR8  mRocRk3566PcFamilyName[] = "ROC-RK3566-PC";
+
+STATIC
+BOOLEAN
+IsRocRk3566Pc (
+  VOID
+  )
+{
+  CONST CHAR8  *FamilyName;
+
+  FamilyName = (CONST CHAR8 *)PcdGetPtr (PcdFamilyName);
+  if (FamilyName == NULL) {
+    return FALSE;
+  }
+
+  return AsciiStrCmp (FamilyName, mRocRk3566PcFamilyName) == 0;
+}
+
+STATIC
+CONST EFI_GUID *
+SelectAcpiTableFile (
+  VOID
+  )
+{
+  if (IsRocRk3566Pc () &&
+      (PcdGet32 (PcdSystemTableMode) == SYSTEM_TABLE_MODE_ACPI)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "ROC-RK3566-PC: installing ACPI-only tables (enriched GMAC1 DSDT)\n"
+      ));
+    return &mRocRk3566PcAcpiOnlyTableFile;
+  }
+
+  return &mAcpiTableFile;
+}
 
 EFI_STATUS
 EFIAPI
@@ -38,5 +81,5 @@ PlatformAcpiDriverEntryPoint (
     return EFI_SUCCESS;
   }
 
-  return LocateAndInstallAcpiFromFv (&mAcpiTableFile);
+  return LocateAndInstallAcpiFromFv (SelectAcpiTableFile ());
 }

--- a/edk2-rockchip/Platform/Rockchip/Rk356x/Drivers/PlatformAcpiDxe/PlatformAcpiDxe.inf
+++ b/edk2-rockchip/Platform/Rockchip/Rk356x/Drivers/PlatformAcpiDxe/PlatformAcpiDxe.inf
@@ -34,6 +34,7 @@
   DxeServicesLib
   AcpiLib
   MemoryAllocationLib
+  PcdLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
 
@@ -43,6 +44,7 @@
 
 [Pcd]
   gRk356xTokenSpaceGuid.PcdSystemTableMode
+  gRk356xTokenSpaceGuid.PcdFamilyName
 
 [Depex]
   gEfiAcpiTableProtocolGuid


### PR DESCRIPTION
Enable onboard Ethernet when the OS boots with ACPI only (no device tree passed to Linux). Production ACPI+DT path is unchanged: stock Dsdt.asl still includes Gmac.asl; the enriched tables install only when ConfigDxe sets PcdSystemTableMode to ACPI-only (0) on ROC-RK3566-PC.

Implement and fix #31

Motivation
----------
Linux on ROC-RK3566-PC with System Table Mode = ACPI exposes PRP0001:03 (\_SB.MAC1) but upstream Gmac.asl omits properties Linux needs to bind rk_gmac-dwmac and drive the external RTL8211F PHY: no rockchip,rk3568-gmac, no phy-mode/delays/GRF, no MDIO PHY graph. The driver falls back to stmmaceth or fails probe. Goal: firmware supplies enough _DSD so a patched in-tree/out-of-tree stmmac can bring up GMAC1 without DT.

ACPI table strategy
-------------------
- Add ROC-RK3566-PC-AcpiOnly.inf (GUID 7C4E9A21-...) building a parallel DSDT from Dsdt-AcpiOnly.asl.
- Dsdt-AcpiOnly.asl mirrors stock ROC DSDT but swaps Gmac.asl for ROC-RK3566-PC/Gmac-MAC1.asl.
- PlatformAcpiDxe selects the ACPI-only FFS when PcdFamilyName is "ROC-RK3566-PC" and PcdSystemTableMode == SYSTEM_TABLE_MODE_ACPI; otherwise installs the existing platform ACPI blob (0FBE0D20-...).
- Package ACPI-only INF in ROC-RK3566-PC.dsc and FDF so tables are always built; runtime selection avoids affecting ACPI+DT boots.

Gmac-MAC1.asl (_SB.MAC1 @ 0xFE010000)
---------------------------------------
_DSD additions vs stock Gmac.asl MAC1:
- compatible: rockchip,rk3568-gmac, snps,dwmac-4.20a, snps,dwmac
- phy-mode: rgmii; clock_in_out: input
- tx_delay 0x4F / rx_delay 0x24 (match rk3566-roc-pc.dts gmac1)
- rockchip,grf: 0xFDC60000 (GRF MMIO when no DT phandle)
- rockchip,uefi-initialized: signals BoardInitDxe already did CRU/GRF/PHY
- snps,mixed-burst, snps,tso, snps,axi-config (AXIC package) retained
- phy-handle -> \_SB.MAC1.PHY0 for real link state via MDIO/phylink (replaces fixed-link; cable unplug -> NO-CARRIER in Linux)

Child Device (PHY0) @ _ADR 0:
- compatible: ethernet-phy-ieee802.3-c22 (MDIO address 0, RTL8211F-class)

Platform / board consequences
-----------------------------
- PcdMac0Status = 0 (hide GMAC0); PcdMac1Status = 0xF (expose GMAC1 only).
- BoardInitDxe: align GRF RGMII delays with DT (TX 0x4F, RX 0x24) so OS driver matches hardware programmed at boot.

Linux coupling (not in this commit)
-----------------------------------
Kernel still needs dwmac-rk ACPI support (GRF fallback, GMAC4/AXI fixups, acpi_mdiobus_register, compatible[] parsing). This firmware change is the ACPI graph those patches expect.